### PR TITLE
handle large update counts

### DIFF
--- a/.github/workflows/broken_links_checker.yml
+++ b/.github/workflows/broken_links_checker.yml
@@ -19,7 +19,10 @@ jobs:
       - name: Configure broken links checker
         run: |
           mkdir -p ./target
-          echo '{ "aliveStatusCodes": [429, 200], "ignorePatterns": [{"pattern": "^https?://(www.)?opensource.org"}] }' > ./target/broken_links_checker.json
+          echo '{"aliveStatusCodes": [429, 200], "ignorePatterns": [' \
+               '{"pattern": "^https?://(www|dev).mysql.com/"},' \
+               '{"pattern": "^https?://(www.)?opensource.org"}' \
+               ']}' > ./target/broken_links_checker.json
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-quiet-mode: 'yes'

--- a/.github/workflows/ci-build-next-java.yml
+++ b/.github/workflows/ci-build-next-java.yml
@@ -25,7 +25,7 @@ jobs:
           cache: 'maven'
       - name: Run tests and build with Maven
         run: |
-          mvn --batch-mode --update-snapshots clean package -DtrimStackTrace=false \
+          mvn --batch-mode --update-snapshots clean package -DtrimStackTrace=false  \
               -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
       - name: Publish Test Report
         uses: scacap/action-surefire-report@v1

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ pom.xml.versionsBackup
 *.flattened-pom.xml
 /.settings/org.eclipse.core.resources.prefs
 /.settings/org.eclipse.jdt.apt.core.prefs
+/.settings/org.eclipse.m2e.core.prefs

--- a/README.md
+++ b/README.md
@@ -1,15 +1,12 @@
 # Jdbc Factory for Exasol
 
 [![Build Status](https://github.com/exasol/exasol-jdbc-connection-factory/actions/workflows/ci-build.yml/badge.svg)](https://github.com/exasol/exasol-jdbc-connection-factory/actions/workflows/ci-build.yml)
-[![Maven Central – Jdbc Connection Factory](https://img.shields.io/maven-central/v/com.exasol/exasol-jdbc-connection-factory)](https://search.maven.org/artifact/com.exasol/exasol-jdbc-connection-factory)
-
+[![Maven Central &ndash; Jdbc Connection Factory](https://img.shields.io/maven-central/v/com.exasol/exasol-jdbc-connection-factory)](https://search.maven.org/artifact/com.exasol/exasol-jdbc-connection-factory)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=com.exasol%3Aexasol-jdbc-connection-factory&metric=alert_status)](https://sonarcloud.io/dashboard?id=com.exasol%3Aexasol-jdbc-connection-factory)
-
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=com.exasol%3Aexasol-jdbc-connection-factory&metric=security_rating)](https://sonarcloud.io/dashboard?id=com.exasol%3Aexasol-jdbc-connection-factory)
 [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=com.exasol%3Aexasol-jdbc-connection-factory&metric=reliability_rating)](https://sonarcloud.io/dashboard?id=com.exasol%3Aexasol-jdbc-connection-factory)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=com.exasol%3Aexasol-jdbc-connection-factory&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=com.exasol%3Aexasol-jdbc-connection-factory)
 [![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=com.exasol%3Aexasol-jdbc-connection-factory&metric=sqale_index)](https://sonarcloud.io/dashboard?id=com.exasol%3Aexasol-jdbc-connection-factory)
-
 [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=com.exasol%3Aexasol-jdbc-connection-factory&metric=code_smells)](https://sonarcloud.io/dashboard?id=com.exasol%3Aexasol-jdbc-connection-factory)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=com.exasol%3Aexasol-jdbc-connection-factory&metric=coverage)](https://sonarcloud.io/dashboard?id=com.exasol%3Aexasol-jdbc-connection-factory)
 [![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=com.exasol%3Aexasol-jdbc-connection-factory&metric=duplicated_lines_density)](https://sonarcloud.io/dashboard?id=com.exasol%3Aexasol-jdbc-connection-factory)

--- a/README.md
+++ b/README.md
@@ -2,11 +2,14 @@
 
 [![Build Status](https://github.com/exasol/exasol-jdbc-connection-factory/actions/workflows/ci-build.yml/badge.svg)](https://github.com/exasol/exasol-jdbc-connection-factory/actions/workflows/ci-build.yml)
 [![Maven Central &ndash; Jdbc Connection Factory](https://img.shields.io/maven-central/v/com.exasol/exasol-jdbc-connection-factory)](https://search.maven.org/artifact/com.exasol/exasol-jdbc-connection-factory)
+
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=com.exasol%3Aexasol-jdbc-connection-factory&metric=alert_status)](https://sonarcloud.io/dashboard?id=com.exasol%3Aexasol-jdbc-connection-factory)
+
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=com.exasol%3Aexasol-jdbc-connection-factory&metric=security_rating)](https://sonarcloud.io/dashboard?id=com.exasol%3Aexasol-jdbc-connection-factory)
 [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=com.exasol%3Aexasol-jdbc-connection-factory&metric=reliability_rating)](https://sonarcloud.io/dashboard?id=com.exasol%3Aexasol-jdbc-connection-factory)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=com.exasol%3Aexasol-jdbc-connection-factory&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=com.exasol%3Aexasol-jdbc-connection-factory)
 [![Technical Debt](https://sonarcloud.io/api/project_badges/measure?project=com.exasol%3Aexasol-jdbc-connection-factory&metric=sqale_index)](https://sonarcloud.io/dashboard?id=com.exasol%3Aexasol-jdbc-connection-factory)
+
 [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=com.exasol%3Aexasol-jdbc-connection-factory&metric=code_smells)](https://sonarcloud.io/dashboard?id=com.exasol%3Aexasol-jdbc-connection-factory)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=com.exasol%3Aexasol-jdbc-connection-factory&metric=coverage)](https://sonarcloud.io/dashboard?id=com.exasol%3Aexasol-jdbc-connection-factory)
 [![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=com.exasol%3Aexasol-jdbc-connection-factory&metric=duplicated_lines_density)](https://sonarcloud.io/dashboard?id=com.exasol%3Aexasol-jdbc-connection-factory)

--- a/dependencies.md
+++ b/dependencies.md
@@ -46,7 +46,7 @@
 
 [0]: http://www.exasol.com
 [1]: https://repo1.maven.org/maven2/com/exasol/exasol-jdbc/7.1.20/exasol-jdbc-7.1.20-license.txt
-[2]: https://maven.apache.org/ref/3.9.2/maven-artifact/
+[2]: https://maven.apache.org/ref/3.9.3/maven-artifact/
 [3]: https://www.apache.org/licenses/LICENSE-2.0.txt
 [4]: https://github.com/exasol/exasol-testcontainers/
 [5]: https://github.com/exasol/exasol-testcontainers/blob/main/LICENSE

--- a/dependencies.md
+++ b/dependencies.md
@@ -13,7 +13,7 @@
 | Dependency                                | License                          |
 | ----------------------------------------- | -------------------------------- |
 | [Test containers for Exasol on Docker][4] | [MIT License][5]                 |
-| [JUnit Jupiter API][6]                    | [Eclipse Public License v2.0][7] |
+| [JUnit Jupiter (Aggregator)][6]           | [Eclipse Public License v2.0][7] |
 | [mockito-junit-jupiter][8]                | [The MIT License][9]             |
 
 ## Plugin Dependencies

--- a/dependencies.md
+++ b/dependencies.md
@@ -3,10 +3,10 @@
 
 ## Compile Dependencies
 
-| Dependency                   | License                          |
-| ---------------------------- | -------------------------------- |
-| [EXASolution JDBC Driver][0] | [EXAClient License][1]           |
-| [Maven Artifact][2]          | [Apache License, Version 2.0][3] |
+| Dependency                   | License                |
+| ---------------------------- | ---------------------- |
+| [EXASolution JDBC Driver][0] | [EXAClient License][1] |
+| [Maven Artifact][2]          | [Apache-2.0][3]        |
 
 ## Test Dependencies
 
@@ -21,31 +21,32 @@
 | Dependency                                              | License                                        |
 | ------------------------------------------------------- | ---------------------------------------------- |
 | [SonarQube Scanner for Maven][10]                       | [GNU LGPL 3][11]                               |
-| [Apache Maven Compiler Plugin][12]                      | [Apache License, Version 2.0][3]               |
-| [Apache Maven Enforcer Plugin][13]                      | [Apache License, Version 2.0][3]               |
+| [Apache Maven Compiler Plugin][12]                      | [Apache-2.0][3]                                |
+| [Apache Maven Enforcer Plugin][13]                      | [Apache-2.0][3]                                |
 | [Maven Flatten Plugin][14]                              | [Apache Software Licenese][3]                  |
 | [org.sonatype.ossindex.maven:ossindex-maven-plugin][15] | [ASL2][16]                                     |
-| [Maven Surefire Plugin][17]                             | [Apache License, Version 2.0][3]               |
+| [Maven Surefire Plugin][17]                             | [Apache-2.0][3]                                |
 | [Versions Maven Plugin][18]                             | [Apache License, Version 2.0][3]               |
-| [Apache Maven Deploy Plugin][19]                        | [Apache License, Version 2.0][3]               |
-| [Apache Maven GPG Plugin][20]                           | [Apache License, Version 2.0][3]               |
-| [Apache Maven Source Plugin][21]                        | [Apache License, Version 2.0][3]               |
-| [Apache Maven Javadoc Plugin][22]                       | [Apache License, Version 2.0][3]               |
-| [Nexus Staging Maven Plugin][23]                        | [Eclipse Public License][24]                   |
-| [Maven Failsafe Plugin][25]                             | [Apache License, Version 2.0][3]               |
-| [JaCoCo :: Maven Plugin][26]                            | [Eclipse Public License 2.0][27]               |
-| [error-code-crawler-maven-plugin][28]                   | [MIT License][29]                              |
-| [Reproducible Build Maven Plugin][30]                   | [Apache 2.0][16]                               |
-| [Project keeper maven plugin][31]                       | [The MIT License][32]                          |
-| [Maven Clean Plugin][33]                                | [The Apache Software License, Version 2.0][16] |
-| [Maven Resources Plugin][34]                            | [The Apache Software License, Version 2.0][16] |
-| [Maven JAR Plugin][35]                                  | [The Apache Software License, Version 2.0][16] |
-| [Maven Install Plugin][36]                              | [The Apache Software License, Version 2.0][16] |
-| [Maven Site Plugin 3][37]                               | [The Apache Software License, Version 2.0][16] |
+| [duplicate-finder-maven-plugin Maven Mojo][19]          | [Apache License 2.0][20]                       |
+| [Apache Maven Deploy Plugin][21]                        | [Apache-2.0][3]                                |
+| [Apache Maven GPG Plugin][22]                           | [Apache License, Version 2.0][3]               |
+| [Apache Maven Source Plugin][23]                        | [Apache License, Version 2.0][3]               |
+| [Apache Maven Javadoc Plugin][24]                       | [Apache-2.0][3]                                |
+| [Nexus Staging Maven Plugin][25]                        | [Eclipse Public License][26]                   |
+| [Maven Failsafe Plugin][27]                             | [Apache-2.0][3]                                |
+| [JaCoCo :: Maven Plugin][28]                            | [Eclipse Public License 2.0][29]               |
+| [error-code-crawler-maven-plugin][30]                   | [MIT License][31]                              |
+| [Reproducible Build Maven Plugin][32]                   | [Apache 2.0][16]                               |
+| [Project keeper maven plugin][33]                       | [The MIT License][34]                          |
+| [Maven Clean Plugin][35]                                | [The Apache Software License, Version 2.0][16] |
+| [Maven Resources Plugin][36]                            | [The Apache Software License, Version 2.0][16] |
+| [Maven JAR Plugin][37]                                  | [The Apache Software License, Version 2.0][16] |
+| [Maven Install Plugin][38]                              | [The Apache Software License, Version 2.0][16] |
+| [Maven Site Plugin 3][39]                               | [The Apache Software License, Version 2.0][16] |
 
 [0]: http://www.exasol.com
-[1]: https://docs.exasol.com/connect_exasol/drivers/jdbc.htm
-[2]: https://maven.apache.org/ref/3.8.6/maven-artifact/
+[1]: https://repo1.maven.org/maven2/com/exasol/exasol-jdbc/7.1.20/exasol-jdbc-7.1.20-license.txt
+[2]: https://maven.apache.org/ref/3.9.2/maven-artifact/
 [3]: https://www.apache.org/licenses/LICENSE-2.0.txt
 [4]: https://github.com/exasol/exasol-testcontainers/
 [5]: https://github.com/exasol/exasol-testcontainers/blob/main/LICENSE
@@ -61,23 +62,25 @@
 [15]: https://sonatype.github.io/ossindex-maven/maven-plugin/
 [16]: http://www.apache.org/licenses/LICENSE-2.0.txt
 [17]: https://maven.apache.org/surefire/maven-surefire-plugin/
-[18]: https://www.mojohaus.org/versions-maven-plugin/
-[19]: https://maven.apache.org/plugins/maven-deploy-plugin/
-[20]: https://maven.apache.org/plugins/maven-gpg-plugin/
-[21]: https://maven.apache.org/plugins/maven-source-plugin/
-[22]: https://maven.apache.org/plugins/maven-javadoc-plugin/
-[23]: http://www.sonatype.com/public-parent/nexus-maven-plugins/nexus-staging/nexus-staging-maven-plugin/
-[24]: http://www.eclipse.org/legal/epl-v10.html
-[25]: https://maven.apache.org/surefire/maven-failsafe-plugin/
-[26]: https://www.jacoco.org/jacoco/trunk/doc/maven.html
-[27]: https://www.eclipse.org/legal/epl-2.0/
-[28]: https://github.com/exasol/error-code-crawler-maven-plugin/
-[29]: https://github.com/exasol/error-code-crawler-maven-plugin/blob/main/LICENSE
-[30]: http://zlika.github.io/reproducible-build-maven-plugin
-[31]: https://github.com/exasol/project-keeper/
-[32]: https://github.com/exasol/project-keeper/blob/main/LICENSE
-[33]: http://maven.apache.org/plugins/maven-clean-plugin/
-[34]: http://maven.apache.org/plugins/maven-resources-plugin/
-[35]: http://maven.apache.org/plugins/maven-jar-plugin/
-[36]: http://maven.apache.org/plugins/maven-install-plugin/
-[37]: http://maven.apache.org/plugins/maven-site-plugin/
+[18]: https://www.mojohaus.org/versions/versions-maven-plugin/
+[19]: https://github.com/basepom/duplicate-finder-maven-plugin
+[20]: http://www.apache.org/licenses/LICENSE-2.0.html
+[21]: https://maven.apache.org/plugins/maven-deploy-plugin/
+[22]: https://maven.apache.org/plugins/maven-gpg-plugin/
+[23]: https://maven.apache.org/plugins/maven-source-plugin/
+[24]: https://maven.apache.org/plugins/maven-javadoc-plugin/
+[25]: http://www.sonatype.com/public-parent/nexus-maven-plugins/nexus-staging/nexus-staging-maven-plugin/
+[26]: http://www.eclipse.org/legal/epl-v10.html
+[27]: https://maven.apache.org/surefire/maven-failsafe-plugin/
+[28]: https://www.jacoco.org/jacoco/trunk/doc/maven.html
+[29]: https://www.eclipse.org/legal/epl-2.0/
+[30]: https://github.com/exasol/error-code-crawler-maven-plugin/
+[31]: https://github.com/exasol/error-code-crawler-maven-plugin/blob/main/LICENSE
+[32]: http://zlika.github.io/reproducible-build-maven-plugin
+[33]: https://github.com/exasol/project-keeper/
+[34]: https://github.com/exasol/project-keeper/blob/main/LICENSE
+[35]: http://maven.apache.org/plugins/maven-clean-plugin/
+[36]: http://maven.apache.org/plugins/maven-resources-plugin/
+[37]: http://maven.apache.org/plugins/maven-jar-plugin/
+[38]: http://maven.apache.org/plugins/maven-install-plugin/
+[39]: http://maven.apache.org/plugins/maven-site-plugin/

--- a/doc/changes/changelog.md
+++ b/doc/changes/changelog.md
@@ -1,3 +1,4 @@
 # Changes
 
+* [1.4.1](changes_1.4.1.md)
 * [1.4.0](changes_1.4.0.md)

--- a/doc/changes/changes_1.4.1.md
+++ b/doc/changes/changes_1.4.1.md
@@ -1,0 +1,39 @@
+# Jdbc Connection Factory 1.4.1, released 2023-??-??
+
+Code name: long is long
+
+## Summary
+
+## Features
+
+* #7: Integer overflow for update operations<br>
+  `executeUpdate()` and `executedUpdatePrepared()` now call `executeLargeUpdate()` on JDBC
+  level to match their `long` return type
+
+## Dependency Updates
+
+### Compile Dependency Updates
+
+* Updated `com.exasol:exasol-jdbc:7.1.16` to `7.1.20`
+* Updated `org.apache.maven:maven-artifact:3.8.6` to `3.9.2`
+
+### Test Dependency Updates
+
+* Updated `com.exasol:exasol-testcontainers:6.4.0` to `6.6.0`
+* Updated `org.junit.jupiter:junit-jupiter-api:5.9.1` to `5.9.3`
+* Updated `org.mockito:mockito-junit-jupiter:4.9.0` to `5.4.0`
+
+### Plugin Dependency Updates
+
+* Updated `com.exasol:error-code-crawler-maven-plugin:1.2.1` to `1.2.3`
+* Updated `com.exasol:project-keeper-maven-plugin:2.9.1` to `2.9.7`
+* Updated `org.apache.maven.plugins:maven-compiler-plugin:3.10.1` to `3.11.0`
+* Updated `org.apache.maven.plugins:maven-deploy-plugin:3.0.0` to `3.1.1`
+* Updated `org.apache.maven.plugins:maven-enforcer-plugin:3.1.0` to `3.3.0`
+* Updated `org.apache.maven.plugins:maven-failsafe-plugin:3.0.0-M7` to `3.0.0`
+* Updated `org.apache.maven.plugins:maven-javadoc-plugin:3.4.1` to `3.5.0`
+* Updated `org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M7` to `3.0.0`
+* Added `org.basepom.maven:duplicate-finder-maven-plugin:1.5.1`
+* Updated `org.codehaus.mojo:flatten-maven-plugin:1.3.0` to `1.4.1`
+* Updated `org.codehaus.mojo:versions-maven-plugin:2.13.0` to `2.15.0`
+* Updated `org.jacoco:jacoco-maven-plugin:0.8.8` to `0.8.9`

--- a/doc/changes/changes_1.4.1.md
+++ b/doc/changes/changes_1.4.1.md
@@ -15,7 +15,7 @@ Code name: long is long
 ### Compile Dependency Updates
 
 * Updated `com.exasol:exasol-jdbc:7.1.16` to `7.1.20`
-* Updated `org.apache.maven:maven-artifact:3.8.6` to `3.9.2`
+* Updated `org.apache.maven:maven-artifact:3.8.6` to `3.9.3`
 
 ### Test Dependency Updates
 

--- a/doc/changes/changes_1.4.1.md
+++ b/doc/changes/changes_1.4.1.md
@@ -1,4 +1,4 @@
-# Jdbc Connection Factory 1.4.1, released 2023-??-??
+# Jdbc Connection Factory 1.4.1, released 2023-07-04
 
 Code name: long is long
 
@@ -20,7 +20,8 @@ Code name: long is long
 ### Test Dependency Updates
 
 * Updated `com.exasol:exasol-testcontainers:6.4.0` to `6.6.0`
-* Updated `org.junit.jupiter:junit-jupiter-api:5.9.1` to `5.9.3`
+* Removed `org.junit.jupiter:junit-jupiter-api:5.9.1`
+* Added `org.junit.jupiter:junit-jupiter:5.9.3`
 * Updated `org.mockito:mockito-junit-jupiter:4.9.0` to `5.4.0`
 
 ### Plugin Dependency Updates

--- a/pk_generated_parent.pom
+++ b/pk_generated_parent.pom
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.exasol</groupId>
     <artifactId>exasol-jdbc-connection-factory-generated-parent</artifactId>
-    <version>1.4.0</version>
+    <version>1.4.1</version>
     <packaging>pom</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -53,7 +53,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
+                <version>3.11.0</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
@@ -62,7 +62,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>enforce-maven</id>
@@ -72,7 +72,7 @@
                         <configuration>
                             <rules>
                                 <requireMavenVersion>
-                                    <version>3.6.3</version>
+                                    <version>[3.8.7,3.9.0)</version>
                                 </requireMavenVersion>
                             </rules>
                         </configuration>
@@ -82,7 +82,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>
-                <version>1.3.0</version>
+                <version>1.4.1</version>
                 <configuration>
                     <updatePomFile>true</updatePomFile>
                     <flattenMode>oss</flattenMode>
@@ -121,7 +121,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M7</version>
+                <version>3.0.0</version>
                 <configuration>
                     <!-- Set the highest log level for coverage testing, so that we
           have a chance to reach branches in the logging lambdas too. -->
@@ -132,7 +132,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
-                <version>2.13.0</version>
+                <version>2.15.0</version>
                 <executions>
                     <execution>
                         <id>display-updates</id>
@@ -148,9 +148,35 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.basepom.maven</groupId>
+                <artifactId>duplicate-finder-maven-plugin</artifactId>
+                <version>1.5.1</version>
+                <executions>
+                    <execution>
+                        <id>default</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <printEqualFiles>true</printEqualFiles>
+                    <failBuildInCaseOfDifferentContentConflict>true</failBuildInCaseOfDifferentContentConflict>
+                    <failBuildInCaseOfEqualContentConflict>true</failBuildInCaseOfEqualContentConflict>
+                    <failBuildInCaseOfConflict>true</failBuildInCaseOfConflict>
+                    <checkCompileClasspath>true</checkCompileClasspath>
+                    <checkRuntimeClasspath>true</checkRuntimeClasspath>
+                    <checkTestClasspath>false</checkTestClasspath>
+                    <quiet>true</quiet>
+                    <preferLocal>true</preferLocal>
+                    <useResultFile>false</useResultFile>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.1</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
@@ -191,7 +217,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.4.1</version>
+                <version>3.5.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -216,6 +242,8 @@
                     <autoReleaseAfterClose>true</autoReleaseAfterClose>
                     <serverId>ossrh</serverId>
                     <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <stagingProgressPauseDurationSeconds>15</stagingProgressPauseDurationSeconds>
+                    <stagingProgressTimeoutMinutes>30</stagingProgressTimeoutMinutes>
                 </configuration>
                 <executions>
                     <execution>
@@ -230,7 +258,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0-M7</version>
+                <version>3.0.0</version>
                 <configuration>
                     <!-- Set the highest log level for coverage testing, so that we have a chance to reach branches
           <property>	                      in the logging lambdas too. -->
@@ -251,7 +279,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.8</version>
+                <version>0.8.9</version>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>
@@ -292,7 +320,7 @@
             <plugin>
                 <groupId>com.exasol</groupId>
                 <artifactId>error-code-crawler-maven-plugin</artifactId>
-                <version>1.2.1</version>
+                <version>1.2.3</version>
                 <executions>
                     <execution>
                         <id>verify</id>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
-            <version>3.9.2</version>
+            <version>3.9.3</version>
             <scope>compile</scope>
         </dependency>
         <!-- testing with exasol testcontainers -->

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.exasol</groupId>
     <artifactId>exasol-jdbc-connection-factory</artifactId>
-    <version>1.4.0</version>
+    <version>1.4.1</version>
     <name>Jdbc Connection Factory</name>
     <description>Simple class to create Connections to Exasol databases</description>
     <url>https://github.com/exasol/exasol-jdbc-connection-factory/</url>
@@ -12,35 +12,35 @@
         <dependency>
             <groupId>com.exasol</groupId>
             <artifactId>exasol-jdbc</artifactId>
-            <version>7.1.16</version>
+            <version>7.1.20</version>
             <scope>compile</scope>
         </dependency>
         <!-- Maven Versioning Stuff -->
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
-            <version>3.8.6</version>
+            <version>3.9.2</version>
             <scope>compile</scope>
         </dependency>
         <!-- testing with exasol testcontainers -->
         <dependency>
             <groupId>com.exasol</groupId>
             <artifactId>exasol-testcontainers</artifactId>
-            <version>6.4.0</version>
+            <version>6.6.0</version>
             <scope>test</scope>
         </dependency>
         <!-- junit 5 -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>5.9.1</version>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.9.3</version>
             <scope>test</scope>
         </dependency>
         <!-- Mockito -->
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>4.9.0</version>
+            <version>5.4.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -55,14 +55,14 @@
             <plugin>
                 <groupId>com.exasol</groupId>
                 <artifactId>project-keeper-maven-plugin</artifactId>
-                <version>2.9.1</version>
+                <version>2.9.7</version>
             </plugin>
         </plugins>
     </build>
     <parent>
         <artifactId>exasol-jdbc-connection-factory-generated-parent</artifactId>
         <groupId>com.exasol</groupId>
-        <version>1.4.0</version>
+        <version>1.4.1</version>
         <relativePath>pk_generated_parent.pom</relativePath>
     </parent>
 </project>

--- a/src/main/java/com/exasol/jdbc/ManagedConnection.java
+++ b/src/main/java/com/exasol/jdbc/ManagedConnection.java
@@ -150,8 +150,7 @@ public long executeUpdate( final String sqlText ) throws SQLException {
     try (
             Statement stmt = m_connection.createStatement()
     ) {
-        // https://www.exasol.com/support/browse/IDEA-426 -- executeLargeUpdate is missing
-        return stmt.executeUpdate( sqlText );
+        return stmt.executeLargeUpdate( sqlText );
     }
 }
 
@@ -171,8 +170,9 @@ public long executeUpdatePrepared( final String sqlText, final Object[] params )
         for (int i = 0; i < params.length; ++i) {
             stmt.setObject( i + 1, params[i] );
         }
-        // https://www.exasol.com/support/browse/IDEA-426 -- executeLargeUpdate is missing
-        return stmt.executeUpdate();
+        // https://exasol.atlassian.net/browse/SPOT-17475 -- executeLargeUpdate is missing for prepared statements
+        stmt.executeUpdate();
+        return stmt.getLargeUpdateCount();
     }
 }
 

--- a/src/test/java/com/exasol/jdbc/ITLargeUpdate.java
+++ b/src/test/java/com/exasol/jdbc/ITLargeUpdate.java
@@ -14,6 +14,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ITLargeUpdate {
 
+    @SuppressWarnings("resource")
     protected final ExasolContainer<? extends ExasolContainer<?>> database = new ExasolContainer<>().withRequiredServices().withReuse(true);
 
     @BeforeAll

--- a/src/test/java/com/exasol/jdbc/ITLargeUpdate.java
+++ b/src/test/java/com/exasol/jdbc/ITLargeUpdate.java
@@ -1,0 +1,78 @@
+package com.exasol.jdbc;
+
+import com.exasol.containers.ExasolContainer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.sql.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ITLargeUpdate {
+
+    protected final ExasolContainer<? extends ExasolContainer<?>> database = new ExasolContainer<>().withRequiredServices().withReuse(true);
+
+    @BeforeAll
+    void startUp() {
+        database.start();
+
+        try (
+                Connection c = database.createConnection()
+        ) {
+            c.createStatement().executeUpdate("create schema row_counter");
+            c.createStatement().executeUpdate("create script count_rows(mul1, mul2) returns rowcount as\n" +
+                    "d1 = decimal(mul1)\n" +
+                    "d2 = decimal(mul2)\n" +
+                    "return { rows_affected = d1*d2 }");
+        } catch (SQLException e) {
+            fail(e);
+        }
+    }
+
+    @AfterAll
+    void cleanUp()
+    {
+        try (
+                Connection c = database.createConnection()
+        ) {
+            c.createStatement().executeUpdate("drop schema row_counter cascade");
+        } catch (SQLException e) {
+            fail(e);
+        }
+        database.stop();
+    }
+
+    // Make sure that executeUpdate() returns correct rowcounts within reasonable bounds
+    @ParameterizedTest
+    @ValueSource(longs = {1, 10, 100, 1000, 10000, 100000, 1000000})
+    void testExecuteUpdate(long row_root) {
+        try (
+                ManagedConnection mc = new ManagedConnection(database.createConnection())
+        ) {
+            assertEquals(row_root*row_root, mc.executeUpdate(String.format(
+                    "execute script row_counter.count_rows(%d, %d)", row_root, row_root
+                )));
+        } catch (SQLException e) {
+            fail(e);
+        }
+    }
+
+    // Make sure that executeUpdatePrepared() returns correct rowcounts within reasonable bounds
+    @ParameterizedTest
+    @ValueSource(longs = {1, 10, 100, 1000, 10000, 100000, 1000000})
+    void testExecuteUpdatePrepared(long row_root) {
+        try (
+                ManagedConnection mc = new ManagedConnection(database.createConnection())
+        ) {
+            assertEquals(row_root*row_root, mc.executeUpdatePrepared(String.format(
+                    "execute script row_counter.count_rows(%d, %d)", row_root, row_root
+            ), new Object[]{}));
+        } catch (SQLException e) {
+            fail(e);
+        }
+    }
+}

--- a/src/test/java/com/exasol/jdbc/ITLargeUpdate.java
+++ b/src/test/java/com/exasol/jdbc/ITLargeUpdate.java
@@ -12,7 +12,7 @@ import java.sql.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class ITLargeUpdate {
+class ITLargeUpdate {
 
     protected final ExasolContainer<? extends ExasolContainer<?>> database = new ExasolContainer<>().withRequiredServices().withReuse(true);
 

--- a/src/test/java/com/exasol/jdbc/ITLargeUpdate.java
+++ b/src/test/java/com/exasol/jdbc/ITLargeUpdate.java
@@ -17,7 +17,7 @@ class ITLargeUpdate {
     protected final ExasolContainer<? extends ExasolContainer<?>> database = new ExasolContainer<>().withRequiredServices().withReuse(true);
 
     @BeforeAll
-    void startUp() {
+    void startUp() throws SQLException {
         database.start();
 
         try (
@@ -28,51 +28,38 @@ class ITLargeUpdate {
                     "d1 = decimal(mul1)\n" +
                     "d2 = decimal(mul2)\n" +
                     "return { rows_affected = d1*d2 }");
-        } catch (SQLException e) {
-            fail(e);
         }
     }
 
     @AfterAll
     void cleanUp()
     {
-        try (
-                Connection c = database.createConnection()
-        ) {
-            c.createStatement().executeUpdate("drop schema row_counter cascade");
-        } catch (SQLException e) {
-            fail(e);
-        }
         database.stop();
     }
 
     // Make sure that executeUpdate() returns correct rowcounts within reasonable bounds
     @ParameterizedTest
     @ValueSource(longs = {1, 10, 100, 1000, 10000, 100000, 1000000})
-    void testExecuteUpdate(long row_root) {
+    void testExecuteUpdate(long row_root) throws SQLException {
         try (
                 ManagedConnection mc = new ManagedConnection(database.createConnection())
         ) {
             assertEquals(row_root*row_root, mc.executeUpdate(String.format(
                     "execute script row_counter.count_rows(%d, %d)", row_root, row_root
                 )));
-        } catch (SQLException e) {
-            fail(e);
         }
     }
 
     // Make sure that executeUpdatePrepared() returns correct rowcounts within reasonable bounds
     @ParameterizedTest
     @ValueSource(longs = {1, 10, 100, 1000, 10000, 100000, 1000000})
-    void testExecuteUpdatePrepared(long row_root) {
+    void testExecuteUpdatePrepared(long row_root) throws SQLException {
         try (
                 ManagedConnection mc = new ManagedConnection(database.createConnection())
         ) {
             assertEquals(row_root*row_root, mc.executeUpdatePrepared(String.format(
                     "execute script row_counter.count_rows(%d, %d)", row_root, row_root
             ), new Object[]{}));
-        } catch (SQLException e) {
-            fail(e);
         }
     }
 }

--- a/src/test/java/com/exasol/jdbc/ITgetConnection.java
+++ b/src/test/java/com/exasol/jdbc/ITgetConnection.java
@@ -11,7 +11,7 @@ import java.sql.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class ITgetConnection {
+class ITgetConnection {
 
 protected final ExasolContainer<? extends ExasolContainer<?>> database = new ExasolContainer<>().withRequiredServices().withReuse(true);
 

--- a/src/test/java/com/exasol/jdbc/ITmanagedConnection.java
+++ b/src/test/java/com/exasol/jdbc/ITmanagedConnection.java
@@ -15,7 +15,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.junit.jupiter.api.Assertions.*;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class ITmanagedConnection {
+class ITmanagedConnection {
 
 protected final ExasolContainer<? extends ExasolContainer<?>> database;
 protected final Connection connection;

--- a/src/test/java/com/exasol/jdbc/TestVersions.java
+++ b/src/test/java/com/exasol/jdbc/TestVersions.java
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.doReturn;
 
 @ExtendWith(MockitoExtension.class)
-public class TestVersions {
+class TestVersions {
 
 @Mock
 private Connection connectionMock;


### PR DESCRIPTION
fixes #7:
- fixed: `executeUpdate()` now calls `executeLargeUpdate()`
- fixed: `executeUpdatePrepared()` now used `getLargeUpdateCount()`
- added: test for update rowcounts